### PR TITLE
Security upgrades to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "eslint": "^3.19.0",
     "find-free-port": "^1.0.2",
     "jswiremock": "^0.3.5",
+    "memcache-server-stream": "1.0.0",
     "memcached-mock": "^0.1.0",
-    "mocha": "^3.4.1",
+    "mocha": "^7.1.1",
     "proxyquire": "^1.8.0",
     "request": "^2.81.0",
-    "request-promise": "^4.2.1",
-    "memcache-server-stream": "1.0.0"
+    "request-promise": "^4.2.1"
   },
   "dependencies": {
     "binford-slf4j": "0.0.1",


### PR DESCRIPTION
`npm audit` found some security vulnerabilities in dependencies of this module. This PR does all the security upgrades possible at this time.

I've created https://github.com/ivanplenty/binford-logger/pull/1 and https://github.com/ivanplenty/binford-slf4j/pull/1 to upgrade the dependencies of our dependencies, but the owner hasn't been active on public repos in years. If those PRs aren't looked at, we can make a new npm dependency from my forks, or switch to something like https://www.npmjs.com/package/xxlogger, to resolve the rest of the dependency vulnerabilities.